### PR TITLE
Allow to specify image tag

### DIFF
--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -44,8 +44,8 @@ jobs:
       - name: Create Helm Repository
         run: helm repo index cache --url https://spreitzer.ch/helm-tailscale
       - name: Create GitHub Pages Artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v4
         with:
           path: cache
       - name: Deploy Helm Repository on GitHub Pages
-        uses: actions/deploy-pages@v1      
+        uses: actions/deploy-pages@v1

--- a/charts/tailscale-derp/templates/deployment.yml
+++ b/charts/tailscale-derp/templates/deployment.yml
@@ -22,7 +22,7 @@ spec:
       {{- end }}
       containers:
       - name: "{{ .Release.Name }}-{{ .Chart.Name }}"
-        image: "{{ .Values.image.name }}:v{{ .Chart.AppVersion }}"
+        image: "{{ .Values.image.name }}:{{ .Values.image.tag | default (printf "v%s" .Chart.AppVersion) }}"
         ports:
         - containerPort: 80
         - containerPort: 443

--- a/charts/tailscale-derp/values.yaml
+++ b/charts/tailscale-derp/values.yaml
@@ -1,6 +1,7 @@
 image:
   name: docker.io/sspreitzer/tailscale-derp
   pullPolicy: IfNotPresent
+  tag: ''
 
 service:
   type: LoadBalancer

--- a/charts/tailscale-proxy/templates/deployment.yml
+++ b/charts/tailscale-proxy/templates/deployment.yml
@@ -34,7 +34,7 @@ spec:
       containers:
       - name: tailscale-proxy
         imagePullPolicy: "{{ .Values.image.pullPolicy }}"
-        image: "{{ .Values.image.name }}:v{{ .Chart.AppVersion }}"
+        image: "{{ .Values.image.name }}:{{ .Values.image.tag | default (printf "v%s" .Chart.AppVersion) }}"
         env:
         - name: TS_EXTRA_ARGS
           value: "--hostname={{ .Values.hostname }}{{ if not (empty .Values.tags) }} --advertise-tags={{ join "," .Values.tags }}{{ end }}{{ if not (empty .Values.up.extra_args) }} {{ .Values.up.extra_args }}{{ end }}"

--- a/charts/tailscale-proxy/values.yaml
+++ b/charts/tailscale-proxy/values.yaml
@@ -20,6 +20,7 @@ dns:
 image:
   name: ghcr.io/tailscale/tailscale
   pullPolicy: IfNotPresent
+  tag: ''
 
 tags: []
 


### PR DESCRIPTION
It's not necessary to update Helm chart often, but it's mandatory to be able set upstream application image name & tag. This PR leases dependency on chart version and allows to specify any image tag. 